### PR TITLE
Multiarch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM scratch
+
+# TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
+ARG TARGETOS
+# TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
+ARG TARGETARCH
+
 WORKDIR /go/bin
-COPY .build/tautulli_exporter-linux-amd64 /go/bin/tautulli_exporter
+COPY .build/tautulli_exporter-$TARGETOS-$TARGETARCH /go/bin/tautulli_exporter
 EXPOSE 9487/tcp
 ENTRYPOINT ["./tautulli_exporter"]

--- a/build.sh
+++ b/build.sh
@@ -13,23 +13,40 @@ creator_name="nwalke"
 package_name="tautulli_exporter"
 full_package_name="$creator_name/$package_name"
 
+available_goarchs=$(go tool dist list | tr '\n' ',')
+available_dockerarchs=$(docker buildx inspect | grep Platforms)
+
 platforms=("darwin" "windows" "netbsd" "openbsd" "linux" "freebsd" "plan9")
+archs=("amd64" "arm64")
+docker_archs=""
 
-for i in "${platforms[@]}"; do
+for p in "${platforms[@]}"; do
+  for a in "${archs[@]}"; do
+    output_name=$package_name'-'$p'-'$a
 
-  output_name=$package_name'-'$i'-amd64'
+    if [ $a = "windows" ]; then
+        output_name+='.exe'
+    fi
 
-  if [ $i = "windows" ]; then
-      output_name+='.exe'
-  fi
+    if [ $(echo ${available_goarchs} | grep -c "$p/$a") -ge 1 ]
+    then
+      echo "Building for $p/$a"
+      GOOS=$p CGO_ENABLED=0 GOARCH=$a go build -a -installsuffix cgo -ldflags "-w -s -X main.version=$version" -o .build/$output_name
 
-  GOOS=$i CGO_ENABLED=0 GOARCH=amd64 go build -a -installsuffix cgo -ldflags "-w -s -X main.version=$version" -o .build/$output_name
+      if [ $(echo ${available_dockerarchs}| grep -c "$p/$a") -ge 1 ]
+      then
+        docker_archs+="$p/$a,"
+      fi
+    else
+      echo "Can't build for $p/$a"
+    fi
+  done
 done
 
-docker build -t $full_package_name .
-docker tag $full_package_name $full_package_name:$version
-docker push $full_package_name
-docker push $full_package_name:$version
+echo "Building docker image for this platforms: ${docker_archs%,}"
+docker buildx build --platform=${docker_archs%,} -t $full_package_name -t $full_package_name:$version --push .
+
+exit
 
 git tag -a $version -m "$version"
 git push origin tag $version


### PR DESCRIPTION
This PR adds multi-arch container image support to the build script as discussed in #3

**Testing**
I tested this on a Ubuntu 22.04.3 LTS VM with Docker 24.0.7. VM preparation as follows:

```shell
# Install Docker
sudo apt update
sudo apt install -y ca-certificates curl gnupg
sudo install -m 0755 -d /etc/apt/keyrings
curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
sudo chmod a+r /etc/apt/keyrings/docker.gpg
echo \
  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
  "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
sudo apt update
sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin

# Install go
sudo apt install -y golang-go

# Configure Docker buildx
sudo docker run --privileged --rm tonistiigi/binfmt --install all
sudo docker buildx create --name mybuilder --bootstrap --use

# Prepare for go build.
go mod init tautulli_exporter.go
go mod tidy
```

I then created conatiner images with `./build.sh 0.0`, please find the results of my test run here: https://hub.docker.com/r/tdeutsch/tautulli_exporter/tags

As for the go artifacts, this is the result of my test:
```
$ ls .build/
tautulli_exporter-darwin-amd64  tautulli_exporter-freebsd-arm64 tautulli_exporter-netbsd-amd64  tautulli_exporter-openbsd-arm64
tautulli_exporter-darwin-arm64  tautulli_exporter-linux-amd64   tautulli_exporter-netbsd-arm64  tautulli_exporter-windows-amd64
tautulli_exporter-freebsd-amd64 tautulli_exporter-linux-arm64   tautulli_exporter-openbsd-amd64 tautulli_exporter-windows-arm64
```


**Changes**
Changes in `build.sh`:
- I added two new variables (`available_goarchs` and `available_dockerarchs`) providing the supported architectures for both go and Docker on the build system
- Like the already existing `platforms` variable, I added another one for the desired architectures named `archs`
- For later, variable `docker_archs` specified but empty
- Lines 23-44 have become a second for-loop. it will now try to compile each combination of `archs` and `platforms`, if supported by go (L31). If the same combination is also supported by Docker (L36), it gets added to `docker_archs` for the image build process
- Line 47 builds the image for everything in `docker_archs`, tags it with version and `latest` and pushes it to docker hub.

Changes in `Dockerfile`:
- For later use ARGs for OS and architecture added
- Line 9: Use those ARGS to copy the correct binary into the congtainer

**Known issues**
Although the change also supports different OS, the creation of the images for Windows will fail because the COPY command in the Dockerfile does not support the extension `*.exe`. A possible solution would be to add a wildcard to COPY so that file extensions match without explicitly specifying them. However, I do not have an environment to build Windows images or to test the build process.